### PR TITLE
46 fix code scanning alert   pinned dependencies

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -280,7 +280,7 @@ jobs:
 
       - name: Install coveragepy
         run: |
-          pip install -r requirements-coveragepy.txt
+          pip install --require-hashes -r requirements-coveragepy.txt
 
       - uses: alire-project/gnatcov-to-codecovio-action@54d55a0259f7b7a272cb25232f0d29a57ee2b699
         with:
@@ -463,8 +463,8 @@ jobs:
 
       - name: Install shpinx with extensions
         run: |
-          pip install -r requirements-sphinx.txt
-          pip install git+https://github.com/AdaCore/sphinxcontrib-adadomain@b5f538f52631f0b71a901e4bf4b7829eb2a07bbb
+          pip install --require-hashes -r requirements-sphinx.txt
+          pip install --require-hashes git+https://github.com/AdaCore/sphinxcontrib-adadomain@b5f538f52631f0b71a901e4bf4b7829eb2a07bbb
 
       - name: rst to ${{ matrix.format }}
         id: rst_to

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -280,8 +280,7 @@ jobs:
 
       - name: Install coveragepy
         run: |
-          pip install \
-          'coveragepy==1.6.0 --hash=sha256:a2a29ec8ee985a5ea27dcc3aa3230bacb6593f38ed102cc6aadf00da74be2de6 --hash=sha256:37a955c9e95da9a6b5c8ae445eb60856e9e631a07528547ff0e45aadb701d925'
+          pip install -r requirements-coveragepy.txt
 
       - uses: alire-project/gnatcov-to-codecovio-action@54d55a0259f7b7a272cb25232f0d29a57ee2b699
         with:
@@ -462,11 +461,10 @@ jobs:
         with:
           cache: pip
 
-      - name: Install docutils and sphinxcontrib-adadomain
+      - name: Install shpinx with extensions
         run: |
-          pip install \
-          'docutils==0.21.2 --hash=sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2' \
-          git+https://github.com/AdaCore/sphinxcontrib-adadomain@b5f538f52631f0b71a901e4bf4b7829eb2a07bbb
+          pip install -r requirements-sphinx.txt
+          pip install git+https://github.com/AdaCore/sphinxcontrib-adadomain@b5f538f52631f0b71a901e4bf4b7829eb2a07bbb
 
       - name: rst to ${{ matrix.format }}
         id: rst_to

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -280,7 +280,7 @@ jobs:
 
       - name: Install coveragepy
         run: |
-          pip install -U \
+          pip install \
           coveragepy==1.6.0 --hash=sha256:a2a29ec8ee985a5ea27dcc3aa3230bacb6593f38ed102cc6aadf00da74be2de6 --hash=sha256:37a955c9e95da9a6b5c8ae445eb60856e9e631a07528547ff0e45aadb701d925
 
       - uses: alire-project/gnatcov-to-codecovio-action@54d55a0259f7b7a272cb25232f0d29a57ee2b699
@@ -464,7 +464,7 @@ jobs:
 
       - name: Install docutils and sphinxcontrib-adadomain
         run: |
-          pip install -U \
+          pip install \
           docutils==0.21.2 --hash=sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2 \
           git+https://github.com/AdaCore/sphinxcontrib-adadomain@b5f538f52631f0b71a901e4bf4b7829eb2a07bbb
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -281,7 +281,7 @@ jobs:
       - name: Install coveragepy
         run: |
           pip install \
-          coveragepy==1.6.0 --hash=sha256:a2a29ec8ee985a5ea27dcc3aa3230bacb6593f38ed102cc6aadf00da74be2de6 --hash=sha256:37a955c9e95da9a6b5c8ae445eb60856e9e631a07528547ff0e45aadb701d925
+          'coveragepy==1.6.0 --hash=sha256:a2a29ec8ee985a5ea27dcc3aa3230bacb6593f38ed102cc6aadf00da74be2de6 --hash=sha256:37a955c9e95da9a6b5c8ae445eb60856e9e631a07528547ff0e45aadb701d925'
 
       - uses: alire-project/gnatcov-to-codecovio-action@54d55a0259f7b7a272cb25232f0d29a57ee2b699
         with:
@@ -465,7 +465,7 @@ jobs:
       - name: Install docutils and sphinxcontrib-adadomain
         run: |
           pip install \
-          docutils==0.21.2 --hash=sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2 \
+          'docutils==0.21.2 --hash=sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2' \
           git+https://github.com/AdaCore/sphinxcontrib-adadomain@b5f538f52631f0b71a901e4bf4b7829eb2a07bbb
 
       - name: rst to ${{ matrix.format }}

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -296,6 +296,7 @@ jobs:
           verbose: true
 
   WaitForSuccessfulScoreCardAnalysis:
+    needs: [pre-commit, GNATprove, Test, FlawFinder]
     runs-on: ubuntu-24.04
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -312,14 +313,7 @@ jobs:
           allowed-conclusions: success
 
   Publish:
-    needs:
-      [
-        pre-commit,
-        GNATprove,
-        Test,
-        FlawFinder,
-        WaitForSuccessfulScoreCardAnalysis,
-      ]
+    needs: [WaitForSuccessfulScoreCardAnalysis]
     runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -278,10 +278,6 @@ jobs:
         with:
           cache: pip
 
-      - name: Install coveragepy
-        run: |
-          pip install --require-hashes -r requirements-coveragepy.txt
-
       - uses: alire-project/gnatcov-to-codecovio-action@54d55a0259f7b7a272cb25232f0d29a57ee2b699
         with:
           fail_ci_if_error: true

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -73,18 +73,10 @@ jobs:
           fetch-tags: true
           filter: tree:0
 
-      - name: Setup Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
-        with:
-          cache: pip
-
-      - name: Install pre-commit
-        run: pip install pre-commit==4.1.0
-
-      - run: git log --no-merges
-
       - name: Run pre-commit
-        run: pre-commit run --all-files --show-diff-on-failure
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
+        with:
+          extra_args: --all-files --show-diff-on-failure
 
   GNATprove:
     runs-on: ubuntu-24.04
@@ -287,7 +279,9 @@ jobs:
           cache: pip
 
       - name: Install coveragepy
-        run: pip install coveragepy==1.6.0
+        run: |
+          pip install -U \
+          coveragepy==1.6.0 --hash=sha256:a2a29ec8ee985a5ea27dcc3aa3230bacb6593f38ed102cc6aadf00da74be2de6 --hash=sha256:37a955c9e95da9a6b5c8ae445eb60856e9e631a07528547ff0e45aadb701d925
 
       - uses: alire-project/gnatcov-to-codecovio-action@54d55a0259f7b7a272cb25232f0d29a57ee2b699
         with:
@@ -469,7 +463,10 @@ jobs:
           cache: pip
 
       - name: Install docutils and sphinxcontrib-adadomain
-        run: pip install -U docutils==0.21.2 git+https://github.com/AdaCore/sphinxcontrib-adadomain
+        run: |
+          pip install -U \
+          docutils==0.21.2 --hash=sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2 \
+          git+https://github.com/AdaCore/sphinxcontrib-adadomain@b5f538f52631f0b71a901e4bf4b7829eb2a07bbb
 
       - name: rst to ${{ matrix.format }}
         id: rst_to

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-https://matrix.to/#/@torsknod:matrix.org.
+<https://matrix.to/#/@torsknod:matrix.org>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -116,7 +116,7 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
@@ -124,5 +124,5 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ currently being supported with security updates.
 
 ## Reporting a Vulnerability
 
-Vulnerabilities may be reported via https://github.com/torsknod2/ieee1788-ada/security/advisories/new.
+Vulnerabilities may be reported via <https://github.com/torsknod2/ieee1788-ada/security/advisories/new>.
 
 Tell them where to go, how often they can expect to get an update on a
 reported vulnerability, what to expect if the vulnerability is accepted or

--- a/alire.toml
+++ b/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788"
 description = "IEEE 1788.1 library"
 long-description = "This library implements the IEEE 1788.1 specification for interval arithmetic."
-version = "0.0.1-dev+21"
+version = "0.0.1-dev+22"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/alire.toml
+++ b/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788"
 description = "IEEE 1788.1 library"
 long-description = "This library implements the IEEE 1788.1 specification for interval arithmetic."
-version = "0.0.1-dev+27"
+version = "0.0.1-dev+28"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/alire.toml
+++ b/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788"
 description = "IEEE 1788.1 library"
 long-description = "This library implements the IEEE 1788.1 specification for interval arithmetic."
-version = "0.0.1-dev+28"
+version = "0.0.1-dev+29"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/alire.toml
+++ b/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788"
 description = "IEEE 1788.1 library"
 long-description = "This library implements the IEEE 1788.1 specification for interval arithmetic."
-version = "0.0.1-dev+26"
+version = "0.0.1-dev+27"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/alire.toml
+++ b/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788"
 description = "IEEE 1788.1 library"
 long-description = "This library implements the IEEE 1788.1 specification for interval arithmetic."
-version = "0.0.1-dev+24"
+version = "0.0.1-dev+25"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/alire.toml
+++ b/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788"
 description = "IEEE 1788.1 library"
 long-description = "This library implements the IEEE 1788.1 specification for interval arithmetic."
-version = "0.0.1-dev+29"
+version = "0.0.1-dev+30"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/alire.toml
+++ b/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788"
 description = "IEEE 1788.1 library"
 long-description = "This library implements the IEEE 1788.1 specification for interval arithmetic."
-version = "0.0.1-dev+30"
+version = "0.0.1-dev+31"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/alire.toml
+++ b/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788"
 description = "IEEE 1788.1 library"
 long-description = "This library implements the IEEE 1788.1 specification for interval arithmetic."
-version = "0.0.1-dev+23"
+version = "0.0.1-dev+24"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/alire.toml
+++ b/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788"
 description = "IEEE 1788.1 library"
 long-description = "This library implements the IEEE 1788.1 specification for interval arithmetic."
-version = "0.0.1-dev+25"
+version = "0.0.1-dev+26"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/alire.toml
+++ b/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788"
 description = "IEEE 1788.1 library"
 long-description = "This library implements the IEEE 1788.1 specification for interval arithmetic."
-version = "0.0.1-dev+22"
+version = "0.0.1-dev+21"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/alire.toml
+++ b/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788"
 description = "IEEE 1788.1 library"
 long-description = "This library implements the IEEE 1788.1 specification for interval arithmetic."
-version = "0.0.1-dev+22"
+version = "0.0.1-dev+23"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/hooks/version_check.py
+++ b/hooks/version_check.py
@@ -79,7 +79,12 @@ parser.add_argument(
     help="Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL or integer)",
     type=parse_log_level,
 )
-args = parser.parse_args()
+parser.add_argument(
+    "--force-version",
+    help="Force to set a specific semantic version",
+    type=semver.Version.parse,
+)
+args: argparse.Namespace = parser.parse_args()
 
 logging.basicConfig(level=args.log_level)
 
@@ -128,6 +133,15 @@ logging.info("Build=%i", build)
 if build > 0:
     version = version.replace(prerelease="dev", build=build)
 logging.info("Calculated Version=%s", version)
+
+if args.force_version:
+    if version != args.force_version:
+        logging.warning(
+            "Forced version %s != calculated version %s",
+            args.force_version,
+            version,
+        )
+    version = args.force_version
 
 SUCCESS: bool = True
 for toml_file in args.files:

--- a/requirements-coveragepy.txt
+++ b/requirements-coveragepy.txt
@@ -1,1 +1,3 @@
 coveragepy==1.6.0 --hash=sha256:a2a29ec8ee985a5ea27dcc3aa3230bacb6593f38ed102cc6aadf00da74be2de6 --hash=sha256:37a955c9e95da9a6b5c8ae445eb60856e9e631a07528547ff0e45aadb701d925
+# These are here, because the coveragepy dependencies do not have hashes:
+flask==1.0.2 --hash=sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05

--- a/requirements-coveragepy.txt
+++ b/requirements-coveragepy.txt
@@ -1,0 +1,1 @@
+coveragepy==1.6.0 --hash=sha256:a2a29ec8ee985a5ea27dcc3aa3230bacb6593f38ed102cc6aadf00da74be2de6 --hash=sha256:37a955c9e95da9a6b5c8ae445eb60856e9e631a07528547ff0e45aadb701d925

--- a/requirements-coveragepy.txt
+++ b/requirements-coveragepy.txt
@@ -1,3 +1,0 @@
-coveragepy==1.6.0 --hash=sha256:a2a29ec8ee985a5ea27dcc3aa3230bacb6593f38ed102cc6aadf00da74be2de6 --hash=sha256:37a955c9e95da9a6b5c8ae445eb60856e9e631a07528547ff0e45aadb701d925
-# These are here, because the coveragepy dependencies do not have hashes:
-flask==1.0.2 --hash=sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05

--- a/requirements-sphinx.txt
+++ b/requirements-sphinx.txt
@@ -1,0 +1,2 @@
+docutils==0.21.2 --hash=sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2
+#git+https://github.com/AdaCore/sphinxcontrib-adadomain@b5f538f52631f0b71a901e4bf4b7829eb2a07bbb

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788_tests"
 description = "IEEE 1788 library tests"
 long-description = "AUnit tests for the Native IEEE 1788 library"
-version = "0.0.1-dev+28"
+version = "0.0.1-dev+29"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788_tests"
 description = "IEEE 1788 library tests"
 long-description = "AUnit tests for the Native IEEE 1788 library"
-version = "0.0.1-dev+21"
+version = "0.0.1-dev+22"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788_tests"
 description = "IEEE 1788 library tests"
 long-description = "AUnit tests for the Native IEEE 1788 library"
-version = "0.0.1-dev+22"
+version = "0.0.1-dev+21"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788_tests"
 description = "IEEE 1788 library tests"
 long-description = "AUnit tests for the Native IEEE 1788 library"
-version = "0.0.1-dev+24"
+version = "0.0.1-dev+25"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788_tests"
 description = "IEEE 1788 library tests"
 long-description = "AUnit tests for the Native IEEE 1788 library"
-version = "0.0.1-dev+25"
+version = "0.0.1-dev+26"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788_tests"
 description = "IEEE 1788 library tests"
 long-description = "AUnit tests for the Native IEEE 1788 library"
-version = "0.0.1-dev+27"
+version = "0.0.1-dev+28"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788_tests"
 description = "IEEE 1788 library tests"
 long-description = "AUnit tests for the Native IEEE 1788 library"
-version = "0.0.1-dev+23"
+version = "0.0.1-dev+24"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788_tests"
 description = "IEEE 1788 library tests"
 long-description = "AUnit tests for the Native IEEE 1788 library"
-version = "0.0.1-dev+26"
+version = "0.0.1-dev+27"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788_tests"
 description = "IEEE 1788 library tests"
 long-description = "AUnit tests for the Native IEEE 1788 library"
-version = "0.0.1-dev+30"
+version = "0.0.1-dev+31"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788_tests"
 description = "IEEE 1788 library tests"
 long-description = "AUnit tests for the Native IEEE 1788 library"
-version = "0.0.1-dev+22"
+version = "0.0.1-dev+23"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -34,7 +34,7 @@
 name = "ieee1788_tests"
 description = "IEEE 1788 library tests"
 long-description = "AUnit tests for the Native IEEE 1788 library"
-version = "0.0.1-dev+29"
+version = "0.0.1-dev+30"
 licenses = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 tags = ["ada", "math", "library"]
 


### PR DESCRIPTION
- Enhance GitHub Actions workflow
  - Update to use pre-commit action
  - Streamline job dependencies
  - Use requirements files for dependency installation
- Add force-version option to version check script for better version control
- Improve URL formatting in documentation files

Security:
- Fixes code scanning alert for unpinned dependencies
- Adds integrity verification through SHA256 hashes
- Improves supply chain security

* Closes #44
* Closes #45
* Closes #46