### PR TITLE
ci: normalize dependabot.yml to canonical org pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,59 +1,36 @@
-# IEEE 1788 Interval Arithmetic native library for Ada
-# Copyright (C) 2024,2025 Torsten Knodt
-
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 3.0 of the License, or (at your option) any later version.
-
-# This library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public
-# License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-# As a special exception to the GNU Lesser General Public License version 3
-# ("LGPL3"), the copyright holders of this Library give you permission to convey
-# to a third party a Combined Work that links statically or dynamically to this
-# Library without providing any Minimal Corresponding Source or Minimal
-# Application Code as set out in 4d or providing the installation information set
-# out in section 4e, provided that you comply with the other provisions of LGPL3
-# and provided that you meet, for the Application the terms and conditions of the
-# license(s) which apply to the Application.
-
-# Except as stated in this special exception, the provisions of LGPL3 will
-# continue to comply in full to this Library. If you modify this Library, you
-# may apply this exception to your version of this Library, but you are not
-# obliged to do so. If you do not wish to do so, delete this exception statement
-# from your version. This exception does not (and cannot) modify any license terms
-# which apply to the Application, with which you must still comply.
-
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Torsten Knodt
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    assignees:
-      - "torsknod2"
-    reviewers:
-      - "torsknod2"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 1
-
-  - package-ecosystem: pip
-    assignees:
-      - "torsknod2"
-    reviewers:
-      - "torsknod2"
+  - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
     open-pull-requests-limit: 1
+    assignees:
+      - torsknod2
+    reviewers:
+      - copilot
+      - torsknod2
+    labels:
+      - "type:ci"
+      - "auto:bot"
+    commit-message:
+      prefix: "ci"
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+    assignees:
+      - torsknod2
+    reviewers:
+      - copilot
+      - torsknod2
+    labels:
+      - "auto:dependencies"
+      - "auto:bot"
+      - "lang:python"
+    commit-message:
+      prefix: "build(deps)"


### PR DESCRIPTION
Normalizes to Apache-2.0 SPDX header + canonical labels/reviewers/prefixes.