### PR TITLE
chore(pre-commit): add ci: section for pre-commit.ci configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,12 @@
 # from your version. This exception does not (and cannot) modify any license terms
 # which apply to the Application, with which you must still comply.
 
+ci:
+  autofix_commit_msg: "chore(pre-commit): auto fixes from pre-commit.ci hooks"
+  autoupdate_commit_msg: "chore(pre-commit): update hook revisions"
+  autoupdate_schedule: weekly
+  skip: []  # all hooks compatible with pre-commit.ci runners
+
 repos:
 - repo: https://github.com/gitleaks/gitleaks
   rev: v8.28.0


### PR DESCRIPTION
## Summary

Adds a `ci:` section to `.pre-commit-config.yaml` to configure [pre-commit.ci](https://pre-commit.ci) now that the app is installed.

### Configuration added
- `autofix_commit_msg`: conventional-commits-formatted auto-fix message
- `autoupdate_commit_msg`: conventional-commits-formatted autoupdate message
- `autoupdate_schedule: weekly`: weekly hook revision updates
- See `skip:` entries in the file for any hooks skipped on CI

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>